### PR TITLE
Add lld to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo dnf install gcc-c++ libX11-devel alsa-lib-devel systemd-devel
 ##### Pacman-based distributions (Arch/Manjaro/Etc...)
 
 ```zsh
-sudo pacman -S libx11 pkgconf alsa-lib
+sudo pacman -S libx11 pkgconf alsa-lib lld
 ```
 
 ##### Solus


### PR DESCRIPTION
It would not compile and run if I didn't install the `lld` package. I'm sure the other *nix OS's might need it too, but I haven't tested it yet.